### PR TITLE
Add the ability to map scalar values from an array to a separate table

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ If the `destination` is the same as the current parsed 'type' (destination of th
 For example, we have this data:
 ```
 [
-    ['id' => 1, 'name' => 'dog', 'tags' => ['useful', 'pet', 'animal']]
-    ['id' => 2, 'name' => 'mouse', 'tags' => ['harmful', 'animal']],
+    ['id' => 1, 'name' => 'dog', 'tags' => ['useful', 'pet', 'animal']],
+    ['id' => 2, 'name' => 'mouse', 'tags' => ['harmful', 'animal']]
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,48 +11,204 @@
 composer require keboola/csvmap
 ```
 
-## Configuration
+## Usage
 
-The module's configuration must be an object where each item's key is a path in the parsed object (`.` delimited for nesting by default).
-
-For example, getting `X` from object `A`:
+For example, map key `key.nested` of each `$data` array item, to CSV column `mappedKey`.
 
 ```
-{
-    "A": {
-        "X": "this"
-    }
-}
+$data = [
+    [
+        'id => '123',
+        'key' => [
+            'nested' => 'value1'
+        ]
+    ] 
+];
+$mapping = [ 
+    'id' => [
+        'type' => 'column', 
+        'mapping' => [
+            'destination' => 'id',
+            'primaryKey' => true,
+        ] 
+    ],
+    'key.nested' => 'mappedKey' 
+];
+
+$rootType = 'rootName';
+$userData = [];
+$parser = new Mapper($mapping, $writeHeader, $rootType);
+$parser->parse($data, $userData);
+
+$files = $parser->getCsvFiles();
+$tempFilePath = $files['rootName']->getPathName();
 ```
 
-Would be done by defining an item with a key `A.X`.
+## Mapping
 
-Each item must contain the information below:
+- The mapping is an array.
+- The **`key`** corresponds to the one root/nested key in the source data. Default delimiter is `.`, eg. `key`, `key.nested`.
+- The **`value`** is the mapping configuration for the given key. It is `string` (shorthand notation) or `array`.
+    - There are 3 types of the mapping, defined by the `type` key:
+    - `type` (optional), `column` by default.
+        - `column` will store the value from its key into a CSV column
+        - `user` will look into an array in the second argument of the parse function and fill a CSV column with its value
+        - `table` will create a "child" CSV and link through a primary key or a hash, if no primary key is defined
 
-- `type`: Optional, `column` by default. Possible values: `column`, `table`, `user`.
-    - `column` will store the value from its key into a CSV column
-    - `table` will create a "child" CSV and link through a primary key or a hash, if no primary key is defined
-    - `user` will look into an array in the second argument of the parse function and fill a CSV column with its value
-
-### Column configuration
+## Column mapping
 
 - `mapping`: Required, must contain `destination`:
     - `destination`: Target column in the output CSV file
     - `primaryKey`: Optional, boolean. If set to true, the column will be included in the primary key
 - `forceType`: Optional, if a value is not scalar, it'll be JSON encoded
 
-### Table configuration
+#### Shorthand notation
+
+- If the **`value`** is the `string`, then it is a shorthand notation for the `column` mapping.
+- The string value corresponds to `mapping.destination`.
+
+Example shorthand notation:
+```
+[
+     'key.nested' => 'mappedKey' 
+]
+``` 
+
+... is equal to 
+```
+[
+    'key.nested' => [
+        'type' => 'column', 
+        'mapping' => [
+            'destination' => 'mappedKey'
+        ] 
+    ]
+]
+```
+
+#### Examples
+Four different `column` mappings.
+```
+[
+    'id' => [
+        'type' => 'column', 
+        'mapping' => [
+            'destination' => 'id',
+            'primaryKey' => true,
+        ] 
+    ],
+    'name' => 'name',
+    'info.url' => 'url,
+    'info.tags' => [
+        'type' => 'column', 
+        'mapping' => [
+            'destination' => 'tags',
+            'forceType' => true,
+        ] 
+    ]
+]
+```
+
+## User mapping
+
+Same as `column`, except the **key** of the object is not searched for in the parsed data, but in an array passed to the parser to inject user data
+
+## Table mapping
 
 - `destination`: Required, a target CSV file name
 - `tableMapping`: Required, mapping of all child table's columns
-    - This is a recursive configuration object that must contain settings by the same definition as the "root" of this configuration
-- `parentKey`: Optional, can be used to set the parent/child link as a primary key in the chuld or override the link's column name in the child
+    - Sub-mapping has the same structure as the root `$mapping`.
+- `parentKey`: Optional, can be used to set the parent/child link as a primary key in the child or override the link's column name in the child
     - `primaryKey`: boolean, same as in `column`
     - `destination`: Name of the link column (if not used, name of the parent table . `_pk` is used by default)
     - `disable`: boolean, if set to non-false value, the parent key in the child table, as well as the column in the parent will not be saved
 
-- If the `destination` is the same as the current parsed 'type' (destination of the parent), `parentKey.disable` **must** be true to preserve consistency of structure of the child and parent
+*Note:*  
+If the `destination` is the same as the current parsed 'type' (destination of the parent),   
+`parentKey.disable` **must** be true to preserve consistency of structure of the child and parent.
 
-### User configuration
 
-Same as `column`, except the **key** of the object is not searched for in the parsed data, but in an array passed to the parser to inject user data
+#### Map scalar items to a separated CSV
+
+- Table mapping is useful when you need to map array of the **objects** to separate CSV tables.
+- But sometimes you need to map an array of the **scalar** (not object) values, for example a list of tags.
+- In this case, you can use an **empty key** in `tableMapping` to map a scalar value.
+
+For example, we have this data:
+```
+[
+    ['id' => 1, 'name' => 'dog', 'tags' => ['useful', 'pet', 'animal']]
+    ['id' => 2, 'name' => 'mouse', 'tags' => ['harmful', 'animal']],
+]
+```
+
+Example mapping:
+```
+[
+    'id' => [
+        'type' => 'column', 
+        'mapping' => [
+            'destination' => 'id',
+            'primaryKey' => true,
+        ]
+    ],
+    'name' => 'name',
+    'tags' => [
+        'type' => 'table',
+        'destination' => 'tags',
+        'tableMapping' => [
+            '' => 'tagName' // empty key used to map scalar value
+        ]
+    ]
+]
+```
+
+Results:
+
+`root.csv`:
+```csv
+"id","name"
+"1","dog"
+"2","mouse"
+```
+
+`tags.csv`:
+```csv
+"tagName","root_pk"
+"useful","1"
+"pet","1"
+"animal","1"
+"harmful","2"
+"animal","2"
+```
+
+
+#### Examples
+
+Mixed `column` and `table` mappings.
+```
+[
+    'id' => [
+        'type' => 'column', 
+        'mapping' => [
+            'destination' => 'id',
+            'primaryKey' => true,
+        ]
+    ],
+    'name' => "name,
+    'addresses' => [
+        'type' => 'table', 
+        'destination' => 'addresses',
+        'tableMapping' => [
+            'number' => 'number',
+            'street' => [
+                'type' => 'table',
+                'destination' => 'streets',
+                'tableMapping' => [
+                    'name' => 'name'
+                ]        
+            ]
+         ]
+    ]
+]
+```

--- a/src/Keboola/CsvMap/Mapper.php
+++ b/src/Keboola/CsvMap/Mapper.php
@@ -71,38 +71,46 @@ class Mapper
         }
     }
 
-    /**
-     * @param array $data
-     */
     public function parse(array $data, array $userData = [])
     {
-        $file = $this->getResultFile();
+        // Create a file, even if there is no data
+        $this->getResultFile();
+
         foreach ($data as $row) {
-            $parsedRow = $this->parseRow($row, $userData);
-
-            try {
-                $file->writeRow($parsedRow);
-            } catch (CsvException $e) {
-                if ($e->getCode() != 3) {
-                    throw $e;
-                }
-
-                $columns = [];
-                foreach ($parsedRow as $key => $value) {
-                    if (!is_scalar($value) && !is_null($value)) {
-                        $columns[$key] = gettype($value);
-                    }
-                }
-                $badCols = join(',', array_keys($columns));
-
-                $exception = new BadDataException("Error writing '{$badCols}' column: " . $e->getMessage(), 0, $e);
-                $exception->setData(['bad_columns' => $columns]);
-                throw $exception;
-            }
+            $this->parseRow($row, $userData);
         }
     }
 
-    protected function parseRow($row, array $userData)
+    /**
+     * @param object|mixed $row
+     */
+    public function parseRow($row, array $userData = [])
+    {
+        $file = $this->getResultFile();
+        $mappedRow = $this->mapRow($row, $userData);
+
+        try {
+            $file->writeRow($mappedRow);
+        } catch (CsvException $e) {
+            if ($e->getCode() != 3) {
+                throw $e;
+            }
+
+            $columns = [];
+            foreach ($mappedRow as $key => $value) {
+                if (!is_scalar($value) && !is_null($value)) {
+                    $columns[$key] = gettype($value);
+                }
+            }
+            $badCols = join(',', array_keys($columns));
+
+            $exception = new BadDataException("Error writing '{$badCols}' column: " . $e->getMessage(), 0, $e);
+            $exception->setData(['bad_columns' => $columns]);
+            throw $exception;
+        }
+    }
+
+    protected function mapRow($row, array $userData)
     {
         $result = [];
         foreach ($this->mapping as $key => $settings) {

--- a/src/Keboola/CsvMap/Mapper.php
+++ b/src/Keboola/CsvMap/Mapper.php
@@ -6,6 +6,7 @@ use Keboola\CsvTable\Table;
 use Keboola\Csv\Exception as CsvException;
 use Keboola\CsvMap\Exception\BadConfigException;
 use Keboola\CsvMap\Exception\BadDataException;
+use function Keboola\Utils\getDataFromPath;
 
 class Mapper
 {
@@ -106,7 +107,11 @@ class Mapper
         $result = [];
         foreach ($this->mapping as $key => $settings) {
             $delimiter = empty($settings['delimiter']) ? '.' : $settings['delimiter'];
-            $propertyValue = \Keboola\Utils\getDataFromPath($key, $row, $delimiter);
+            // Empty key means "self", ... it is useful to map scalar array values
+            // Eg. row = {"actors":["Patrick Wilson","Rose Byrne","Barbara Hershey"]}
+            //     mapping = {"actors: {"type": "table", "destination": "actor", "tableMapping": {"": "name:} }
+            $propertyValue = $key === '' && is_scalar($row) ? $row : getDataFromPath($key, $row, $delimiter);
+
             if (empty($settings['type'])) {
                 $settings['type'] = 'column';
             }

--- a/tests/Keboola/CsvMap/MapperTest.php
+++ b/tests/Keboola/CsvMap/MapperTest.php
@@ -253,7 +253,7 @@ class MapperTest extends TestCase
         ];
 
         $data = [
-            (object) [
+            (object)[
                 'id' => 1
             ]
         ];
@@ -281,11 +281,11 @@ class MapperTest extends TestCase
         ];
 
         $data = [
-            (object) [
+            (object)[
                 'id' => 1,
                 'str' => 'asdf'
             ],
-            (object) [
+            (object)[
                 'id' => 2
             ]
         ];
@@ -486,7 +486,7 @@ class MapperTest extends TestCase
             ],
             file($result['root']->getPathName())
         );
-        $this->assertEquals(['id','userCol'], $result['root']->getPrimaryKey(true));
+        $this->assertEquals(['id', 'userCol'], $result['root']->getPrimaryKey(true));
 
         $this->assertEquals(
             [
@@ -691,13 +691,13 @@ class MapperTest extends TestCase
     public function testChildSameParser()
     {
         $data = [
-            (object) [
+            (object)[
                 'id' => 1,
-                'child' => (object) [
+                'child' => (object)[
                     'id' => 1.1
                 ],
                 'arrChild' => [ // redundant?
-                    (object) ['id' => '1.2']
+                    (object)['id' => '1.2']
                 ]
             ]
         ];
@@ -747,7 +747,7 @@ class MapperTest extends TestCase
         ];
 
         $data = [
-            (object) [
+            (object)[
                 'arr' => [
                     'one', 'two'
                 ]
@@ -801,13 +801,13 @@ class MapperTest extends TestCase
         ];
 
         $data = [
-            (object) [
+            (object)[
                 'id' => 1,
                 'child' => [
-                    (object) [
+                    (object)[
                         'id' => 2,
                         'grandchild' => [
-                            (object) [
+                            (object)[
                                 'id' => 3
                             ]
                         ]
@@ -819,7 +819,7 @@ class MapperTest extends TestCase
         $parser = new Mapper($config);
         $parser->parse($data);
 
-        $this->assertEquals(['root','child','grandchild'], array_keys($parser->getCsvFiles()));
+        $this->assertEquals(['root', 'child', 'grandchild'], array_keys($parser->getCsvFiles()));
     }
 
     public function testMixedDataError()
@@ -969,17 +969,75 @@ class MapperTest extends TestCase
         $this->assertEquals(['id', 'time'], $file->getHeader());
     }
 
+    public function testScalarArrayToSeparatedTable(): void
+    {
+        $mapping = [
+            'id' => [
+                'type' => 'column',
+                'mapping' => [
+                    'destination' => 'id',
+                    'primaryKey' => true,
+                ]
+
+            ],
+            "title" => "title",
+            'actors' => [
+                'type' => 'table',
+                'destination' => 'actor',
+                'tableMapping' => [
+                    '' => 'name' // <<<<< empty string means "self"
+                ]
+            ],
+        ];
+
+        $data = [
+            ["id" => 1, "title" => 'Rush', "actors" => ["Daniel Bruhl", "Chris Hemsworth", "Olivia Wilde"]],
+            ["id" => 2, "title" => 'Prisoners', "actors" => ["Hugh Jackman", "Jake Gyllenhaal", "Viola Davis"]],
+            ["id" => 3, "title" => 'Insidious 2', "actors" => ["Patrick Wilson", "Rose Byrne", "Barbara Hershey"]]
+        ];
+
+        $parser = new Mapper($mapping);
+        $parser->parse($data);
+
+        $files = $parser->getCsvFiles();
+        $this->assertCount(2, $files);
+
+        // Check root file
+        $expectedRoot = [
+            '"id","title"' . PHP_EOL,
+            '"1","Rush"' . PHP_EOL,
+            '"2","Prisoners"' . PHP_EOL,
+            '"3","Insidious 2"' . PHP_EOL
+        ];
+        $this->assertEquals($expectedRoot, file($files['root']->getPathName()));
+
+        // Check actors file
+        $expectedActor = [
+            '"name","root_pk"' . PHP_EOL,
+            '"Daniel Bruhl","1"' . PHP_EOL,
+            '"Chris Hemsworth","1"' . PHP_EOL,
+            '"Olivia Wilde","1"' . PHP_EOL,
+            '"Hugh Jackman","2"' . PHP_EOL,
+            '"Jake Gyllenhaal","2"' . PHP_EOL,
+            '"Viola Davis","2"' . PHP_EOL,
+            '"Patrick Wilson","3"' . PHP_EOL,
+            '"Rose Byrne","3"' . PHP_EOL,
+            '"Barbara Hershey","3"' . PHP_EOL,
+        ];
+        $this->assertEquals($expectedActor, file($files['actor']->getPathName()));
+    }
+
     protected function getMixedData()
     {
         return [
-            (object) [
+            (object)[
                 'id' => 1,
                 'arr' => [
                     1.1,
                     1.2
                 ]
             ],
-            (object) [ // poor data
+            (object)[ // poor data
                 'id' => 2,
                 'arr' => 2.1
             ]
@@ -989,23 +1047,23 @@ class MapperTest extends TestCase
     protected function getSampleData()
     {
         return [
-            (object) [
+            (object)[
                 'timestamp' => 1234567890,
                 'id' => 1,
                 'text' => 'asdf',
-                'user' => (object) [
+                'user' => (object)[
                     'id' => 123,
                     'username' => 'alois'
                 ],
                 'reactions' => [
-                    (object) [
-                        'user' => (object) [
+                    (object)[
+                        'user' => (object)[
                             'id' => 456,
                             'username' => 'jose'
                         ]
                     ],
-                    (object) [
-                        'user' => (object) [
+                    (object)[
+                        'user' => (object)[
                             'id' => 789,
                             'username' => 'mike'
                         ]


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/COM-469

Changes:
- Better [documentation](https://github.com/keboola/php-csvmap/blob/webrouse-COM-469-enhancements/README.md).
- Added public `parseRow` method", so single row can be parsed too.
- Add the ability to map scalar values from an array to a separated CSV table.